### PR TITLE
Shadow variables

### DIFF
--- a/10.1-final_project/apps/design-system/src/molecules/ChangelogCard.module.scss
+++ b/10.1-final_project/apps/design-system/src/molecules/ChangelogCard.module.scss
@@ -2,6 +2,7 @@
 @use "../settings/colors";
 @use "../settings/spacing";
 @use "../settings/typography";
+@use "../settings/shadows";
 
 .card {
   position: relative;
@@ -13,6 +14,8 @@
   background: no-repeat center bottom;
   background-size: cover;
   border-radius: border.$radius-default;
+  box-shadow: shadows.$shadow-md;
+  
 
   &--light:not(.card--codely) {
     color: colors.$white;

--- a/10.1-final_project/apps/design-system/src/settings/_shadows.scss
+++ b/10.1-final_project/apps/design-system/src/settings/_shadows.scss
@@ -1,0 +1,3 @@
+
+$shadow-md: 0 4px 30px rgb(0 0 0 / 20%);
+$shadow-lg: 0 20px 50px rgb(0 0 0 / 25%);

--- a/10.1-final_project/apps/mooc/src/sections/codely/Hero.module.scss
+++ b/10.1-final_project/apps/mooc/src/sections/codely/Hero.module.scss
@@ -2,6 +2,7 @@
 @use "@codely/design-system/src/settings/sizes";
 @use "@codely/design-system/src/settings/spacing";
 @use "@codely/design-system/src/settings/typography";
+@use "@codely/design-system/src/settings/shadows";
 @use "@codely/design-system/src/tools/typography" as mixins;
 
 .hero {
@@ -51,7 +52,7 @@
     flex-shrink: 0;
     overflow: hidden;
     border-radius: border.$radius-xl;
-    box-shadow: 0 20px 50px rgb(0 0 0 / 25%);
+    box-shadow: shadows.$shadow-lg;
 
     // Fix for player border radius in Safari
     > * {

--- a/10.1-final_project/apps/mooc/src/sections/codely/Value.module.scss
+++ b/10.1-final_project/apps/mooc/src/sections/codely/Value.module.scss
@@ -1,6 +1,7 @@
 @use "@codely/design-system/src/settings/border";
 @use "@codely/design-system/src/settings/sizes";
 @use "@codely/design-system/src/settings/spacing";
+@use "@codely/design-system/src/settings/shadows";
 
 .value {
   display: flex;
@@ -25,7 +26,7 @@
     display: none;
     overflow: hidden;
     border-radius: border.$radius-xl;
-    box-shadow: 0 20px 50px rgb(0 0 0 / 25%);
+    box-shadow: shadows.$shadow-md;
 
     // Fix for player border radius in Safari
     > * {


### PR DESCRIPTION
He añadido las variables de shadow que se especifican en el diseño de Soluble y sustituido donde correspondían.

Además:

1. En el módulo Value.module.scss se usaba un valor de sombra que con corresponde con el indicado en el Figma para las cards.
2. He añadido la sombra al componente ChangeLogCard tal y como aparece en el diseño en Figma. Creo que le da un toque de elevación que queda muy bien.

Con sombra (igual que en el Figma):
![image](https://user-images.githubusercontent.com/1980155/177051919-84d0dc4e-41b7-4975-864f-be53f5552956.png)


Sin sombra (como está en PRO):
![image](https://user-images.githubusercontent.com/1980155/177051967-07548867-bae8-473a-9f61-f3e13b4f296f.png)
